### PR TITLE
fix: repos without owner

### DIFF
--- a/gocovparser/core.go
+++ b/gocovparser/core.go
@@ -26,7 +26,7 @@ const (
 var parseLineRegex = regexp.MustCompile(
 	`(?P<host>[^\/]*)\/` + // github.com
 		`(?P<owner>[^\/]*)\/` + // heynemann
-		`(?P<repo>[^\/]*)\/` + // gocovparser
+		`(?:(?P<repo>[^\/]*)\/)?` + // gocovparser
 		`(?P<path>.*)\:` + // gocovparser/core.go
 		`(?P<lineno1>\d+)[.](?P<column1>\d+)\,` + // 10.73
 		`(?P<lineno2>\d+)[.](?P<column2>\d+)\s` + // 14.2

--- a/gocovparser/core_test.go
+++ b/gocovparser/core_test.go
@@ -59,6 +59,38 @@ func TestCanGroupCoverageData(t *testing.T) {
 		},
 
 		{
+			name: "Can parse coverage data by package, file and total for file without repo",
+			args: args{
+				coverageData: CoverageFixture5(t),
+				groups: []gocovparser.ParseGroup{
+					gocovparser.PackageParseGroup,
+					gocovparser.FileParseGroup,
+					gocovparser.TotalParseGroup,
+				},
+			},
+			expectedErr: nil,
+			expectedData: func(t *testing.T, result gocovparser.ParseGroupResult) {
+				t.Helper()
+
+				assert.Contains(t, result, "package")
+				assert.Contains(t, result["package"], "go.uber.org/zap")
+				assert.EqualValues(t, 1, result["package"]["go.uber.org/zap"])
+
+				assert.Contains(t, result, "file")
+				assert.Contains(t, result["file"], "go.uber.org/zap/writer.go")
+				assert.EqualValues(t, 1, result["file"]["go.uber.org/zap/writer.go"])
+
+				assert.Contains(t, result, "total")
+				assert.Contains(t, result["total"], "total")
+				assert.EqualValues(
+					t,
+					1,
+					result["total"]["total"],
+				)
+			},
+		},
+
+		{
 			name: "Can parse coverage data by package, file and total for another coverage file format",
 			args: args{
 				coverageData: CoverageFixture2(t),

--- a/gocovparser/fixtures_test.go
+++ b/gocovparser/fixtures_test.go
@@ -323,3 +323,13 @@ func CoverageFixture4(t *testing.T) string {
 
 	return string(contents)
 }
+
+// CoverageFixture4 is a mock coverage.out contents.
+func CoverageFixture5(t *testing.T) string {
+	t.Helper()
+
+	return `
+mode: set
+go.uber.org/zap/writer.go:50.65,52.16 2 1
+`
+}


### PR DESCRIPTION
This commit fixes parsing coverage for repos without owner/repo.